### PR TITLE
Fix for a missing octicon

### DIFF
--- a/_includes/sections/projects.html
+++ b/_includes/sections/projects.html
@@ -27,7 +27,7 @@
                           <a class="github-button" href="{{ project.url | prepend: 'https://github.com'}}" data-icon="octicon-star" data-count-href="{{ project.url | append: '/stargazers' }}" data-count-api="{{ project.url | prepend: '/repos' | append: '#stargazers_count' }}" data-count-aria-label="# stargazers on GitHub" aria-label="Star hydepress/jekyll-install on GitHub">Star</a>
                       </li>
                       <li>
-                          <a class="github-button" href="{{ project.url | prepend: 'https://github.com'}}" data-icon="octicon-fork" data-count-href="{{ project.url | append: '/network/members' }}" data-count-api="{{ project.url | prepend: '/repos' | append: '#forks_count' }}" data-count-aria-label="# forks on GitHub" aria-label="Star hydepress/jekyll-install on GitHub">Fork</a>
+                          <a class="github-button" href="{{ project.url | prepend: 'https://github.com'}}" data-icon="octicon-repo-forked" data-count-href="{{ project.url | append: '/network/members' }}" data-count-api="{{ project.url | prepend: '/repos' | append: '#forks_count' }}" data-count-aria-label="# forks on GitHub" aria-label="Star hydepress/jekyll-install on GitHub">Fork</a>
                       </li>
                   </ul>
                   {% endif %}


### PR DESCRIPTION
Just saw that the fork icon was missing from the button and found that it the octicon wasn't registering due to incorrect addressing.
"octicon-fork"  -> "octicon-repo-forked"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jiakunup/jalpc_jekyll_theme/39)
<!-- Reviewable:end -->
